### PR TITLE
Formidable upload forms

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,6 @@
 import express from 'express';
+import formidable from 'formidable';
+import fs from 'fs';
 
 //var PouchDB = require('pouchdb');
 //var db = new PouchDB('my_database');
@@ -17,6 +19,44 @@ app.get('/watch', (req,res) => {
 
   res.send(html)
   
+})
+
+// This simply returns a fileupload html form on GET /upload
+app.get('/upload', (req,res) => {
+  // TODO: move this into an ejs partial.
+  res.send('<form action="fileupload" method="post" enctype="multipart/form-data"><input type="file" name="filetoupload"><br><input type="submit"></form>');
+})
+
+app.post('/fileupload', (req,res) => {
+  var form = new formidable.IncomingForm();
+
+  // When formidable parses files, they are stored in a temp folder.
+  // So they have to be moved from the oldPath to the newPath
+  // with fs.rename
+  form.parse(req, function (err, fields, files) {
+    var oldpath = ((files.filetoupload as unknown) as formidable.File ).path;
+
+    // Uploaded filename. Weird casting neccessary because formidable type definitions are wrong.
+    var filename = ((files.filetoupload as unknown) as formidable.File ).name;
+
+    // TODO: add user folders in /public/data/... based on UUID
+    // This can only be solved once the login system is in place
+    // Use the parsed info created upstream and bound to 'req'.
+    // Like : newpath = './public/data/' + req.uuid + ....
+    // eg : newpath = './public/data/231239-123921/banana.glb'
+    var newpath = './public/data/' + filename;
+
+    //console.log( oldpath + " ->>> " + newpath)
+    console.log("File uploaded in " + newpath)
+
+    fs.rename(oldpath, newpath, function (err) {
+      if (err) throw err;
+      // TODO: reply with an ejs page to let the user know the upload was successful.
+      res.write('Successfully uploaded!');
+      res.end();
+    });
+    
+  });
 })
 
 app.get('/register', (req,res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -695,6 +695,11 @@
         "unpipe": "~1.0.0"
       }
     },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,15 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-4sVIjd51AADf4YnpsdqNQh7n3ZRLo16w+w6F7zzKjK6dBsQc9Vrq8GQLpHOOWq0V8Fe2bbp2EpihHx57iVgm5Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@types/express": "4.17.6",
+    "@types/formidable": "^1.2.1",
     "@types/node": "14.0.13",
     "nodemon": "^2.0.7",
     "ts-node": "8.10.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "ejs": "^3.1.6",
     "express": "^4.17.1",
+    "formidable": "^1.2.2",
     "pouchdb": "^7.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Changes:
+ Adds the GET /upload page to the app.
+ Form data is sent on a POST to /fileupload.

Mechanism:
+ Formidable parses the incoming file, places it in a temp folder, and then we take it from there and place it in:
/public/data/ ....

A modification should be made once the user account system is in place. ( Please read notes ).

Essentially, files should be put in each user's data folder like : 
```
'./public/data/231239-123921/banana.glb'
```

Also, upon a successful file upload, a formated EJS page should be sent back to the user. ( later TODO )